### PR TITLE
Support for gluster_cluster_options

### DIFF
--- a/roles/gluster_volume/tasks/main.yml
+++ b/roles/gluster_volume/tasks/main.yml
@@ -11,4 +11,5 @@
         disperses: "{{ gluster_cluster_disperse_count | default(0) }}"
         redundancies: "{{ gluster_cluster_redundancy_count | default(0) }}"
         force: "{{ gluster_cluster_force | default('no') }}"
+        options: "{{ gluster_cluster_options | default({}) }}"
   run_once: true


### PR DESCRIPTION
The `gluster_volume` module in Ansible supports passing options, see for example https://github.com/ansible/ansible/blob/7d2c71462d9ed7ed9b524b73c9c3868a1c0f1ed6/lib/ansible/modules/storage/glusterfs/gluster_volume.py#L112

Currently it's impossible to pass those options using `gluster-ansible-cluster`, and this simple patch adds such possibility, by default still not passing any options (`{}` - empty dict).