### PR TITLE
Fix spacing in tasks main.yml to pass ansible-lint

### DIFF
--- a/roles/gluster_volume/tasks/main.yml
+++ b/roles/gluster_volume/tasks/main.yml
@@ -16,7 +16,7 @@
         cluster: "{{ gluster_cluster_hosts }}"
         transport: "{{ gluster_cluster_transport | default('tcp') }}"
         replicas: "{{ gluster_cluster_replica_count | default(0) }}"
-        arbiters: "{{ gluster_cluster_arbiter_count | default(0)}}"
+        arbiters: "{{ gluster_cluster_arbiter_count | default(0) }}"
         disperses: "{{ gluster_cluster_disperse_count | default(0) }}"
         redundancies: "{{ gluster_cluster_redundancy_count | default(0) }}"
         force: "{{ gluster_cluster_force | default('no') }}"


### PR DESCRIPTION
## Overview

Fix spacing on Jinja variable in gluster_volume task. 

## Purpose
When running `ansible-lint` against the gluster_volume task, an error is given that a space is required between variable name and the parentheses.  If this is part of a CI/CD pipeline, this causes the pipeline to fail.

This also brings the spacing in the task for the arbiters in line with the restvof the file.